### PR TITLE
install passlib

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -75,6 +75,11 @@
     name: ansible
     state: latest
 
+- name: Install passlib
+  ansible.builtin.apt:
+    name: python3-passlib
+    state: latest
+
 # End Install apt
 #
 # -----------------------------


### PR DESCRIPTION
Fixes this warning:

2023-03-26 06:15:12,521 p=4186826 u=asterr n=ansible | [DEPRECATION WARNING]: Encryption using the Python crypt module is deprecated. The Python crypt module is deprecated and will be removed from Python 3.13. Install the passlib library for continued encryption functionality. This feature will be removed in version 2.17.