### PR TITLE
Upgrade base duplicati package for Ubuntu 24.04

### DIFF
--- a/roles/duplicati/tasks/main.yml
+++ b/roles/duplicati/tasks/main.yml
@@ -48,12 +48,12 @@
 
 - name: Fetch Duplicati Package
   ansible.builtin.get_url:
-    url: https://github.com/duplicati/duplicati/releases/download/v2.0.6.104-2.0.6.104_canary_2022-06-15/duplicati_2.0.6.104-1_all.deb
-    dest: "{{ ansible_env.HOME }}/Downloads/duplicati_2.0.6.104-1_all.deb"
+    url: https://github.com/duplicati/duplicati/releases/download/v2.0.9.100_canary_2024-05-30/duplicati-2.0.9.100_canary_2024-05-30-linux-arm64-cli.deb
+    dest: "{{ ansible_env.HOME }}/Downloads/duplicati-2.0.9.100_canary_2024-05-30-linux-arm64-cli.deb"
 
 - name: Install Duplicati Package
   ansible.builtin.apt:
-    deb: "{{ ansible_env.HOME }}/Downloads/duplicati_2.0.6.104-1_all.deb"
+    deb: "{{ ansible_env.HOME }}/Downloads/duplicati-2.0.9.100_canary_2024-05-30-linux-arm64-cli.deb"
 
 - name: Duplicati Service
   ansible.builtin.service:


### PR DESCRIPTION
- Old version fails to install
- https://github.com/duplicati/duplicati/issues/5178

$ cat /etc/issue
Ubuntu 24.04 LTS \n \l
$ sudo apt-get install duplicati_2.0.7.1-1_all.deb Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'duplicati' instead of 'duplicati_2.0.7.1-1_all.deb' Some packages could not be installed. This may mean that you have requested an impossible situation or if you are using the unstable distribution that some required packages have not yet been created or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
duplicati : Depends: libappindicator0.1-cil but it is not installable or libappindicator3-0.1-cil but it is not installable or libayatana-appindicator1 but it is not installable Depends: gtk-sharp2 but it is not installable
E: Unable to correct problems, you have held broken packages.